### PR TITLE
setup.sh: correct kernel-ci username

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,12 +4,12 @@ if [[ -n "$LAVA_SERVER_IP" ]]; then
 	sed -i "s/.*LAVA_SERVER_IP =.*/LAVA_SERVER_IP = $LAVA_SERVER_IP/g" /etc/lava-dispatcher/lava-dispatcher.conf
 fi
 # Create the kernelci user
-echo "from django.contrib.auth.models import User; User.objects.create_superuser('kernelci', 'admin@localhost.com', 'kernelci')" | lava-server manage shell
+echo "from django.contrib.auth.models import User; User.objects.create_superuser('kernel-ci', 'admin@localhost.com', 'kernel-ci')" | lava-server manage shell
 # Set the kernelci user's API token
 if [[ -n "$LAVA_API_TOKEN" ]]; then
-	lava-server manage tokens add --user kernelci --secret $LAVA_API_TOKEN
+	lava-server manage tokens add --user kernel-ci --secret $LAVA_API_TOKEN
 else
-	lava-server manage tokens add --user kernelci
+	lava-server manage tokens add --user kernel-ci
 fi
 # By default add a worker on the master
 lava-server manage pipeline-worker --hostname $(hostname)


### PR DESCRIPTION
By default, the kernelci.org infrastructure is submitting jobs using
the username kernel-ci (with a dash).  Fix that, and also rename the
superuser for consistency.