### PR TITLE
Dockerfile: add ser2net, u-boot-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN echo 'lava-server   lava-server/instance-name string lava-docker-instance' |
  qemu-system-arm \
  qemu-system-i386 \
  qemu-kvm \
+ ser2net \
+ u-boot-tools \
  && a2enmod proxy \
  && a2enmod proxy_http \
  && a2dissite 000-default \


### PR DESCRIPTION
ser2net and u-boot-tools (for mkimage) are useful additional packages
to have installed by default.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>