### PR TITLE
Dockerfile: install python-setproctitle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN echo 'lava-server   lava-server/instance-name string lava-docker-instance' |
  qemu-kvm \
  ser2net \
  u-boot-tools \
+ python-setproctitle \
  && a2enmod proxy \
  && a2enmod proxy_http \
  && a2dissite 000-default \


### PR DESCRIPTION
Without python-setproctitle installed, all jobs have a warning:

   WARNING:root:Unable to import 'setproctitle', process name cannot be changed

which also causes a bunch of ther debug messages to appear in red at the
top of every job.

This proably needs to be fixed in LAVA as a debian package dependency also.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>