### PR TITLE
Permit to create staff/superuser users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ lava_server_users:
 	- name: LAVA username
 	  token: The token of this use
 	  password: Password the this user (generated if not provided)
+	  superuser: yes/no (default no)
+	  staff: yes/no (default no)
 callback_tokens:
   - filename: The filename for storing the informations below, the name should be unique along other callback tokens
     username: The LAVA user owning the token below. (This user should be created via lava_server_users:)

--- a/lava-master/Dockerfile
+++ b/lava-master/Dockerfile
@@ -45,11 +45,6 @@ RUN service postgresql start \
  && a2ensite lava-server \
  && /stop.sh
 
-# Create a admin user (Insecure note, this creates a default user, username: admin/admin)
-RUN /start.sh \
- && lava-server manage users add --passwd admin --staff --superuser --email admin@example.com admin \
- && /stop.sh
-
 # Install latest
 #RUN /start.sh \
 # && git clone https://github.com/kernelci/lava-dispatcher.git -b master  /root/lava-dispatcher \

--- a/lava-master/scripts/setup.sh
+++ b/lava-master/scripts/setup.sh
@@ -5,14 +5,23 @@ if [ -e /root/lava-users ];then
 	do
 		# User is the filename
 		USER=$ut
+		USER_OPTION=""
+		STAFF=0
+		SUPERUSER=0
 		. /root/lava-users/$ut
 		if [ -z "$PASSWORD" -o "$PASSWORD" = "$TOKEN" ];then
 			echo "Generating password..."
 			#Could be very long, should be avoided
 			PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 		fi
-		echo "Adding username $USER DEBUG(with $TOKEN / $PASSWORD)"
-		lava-server manage users add --passwd $PASSWORD $USER || exit 1
+		if [ $STAFF -eq 1 ];then
+			USER_OPTION="$USER_OPTION --staff"
+		fi
+		if [ $SUPERUSER -eq 1 ];then
+			USER_OPTION="$USER_OPTION --superuser"
+		fi
+		echo "Adding username $USER DEBUG(with $TOKEN / $PASSWORD / $USER_OPTION)"
+		lava-server manage users add --passwd $PASSWORD $USER_OPTION $USER || exit 1
 		if [ ! -z "$TOKEN" ];then
 			lava-server manage tokens add --user $USER --secret $TOKEN || exit 1
 		fi

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -120,7 +120,16 @@ def main(args):
                 ftok.write("TOKEN=" + token + "\n")
                 if user.has_key("password"):
                     password = user["password"]
-                    ftok.write("PASSWORD=" + password)
+                    ftok.write("PASSWORD=" + password + "\n")
+                # libyaml convert yes/no to true/false...
+                if user.has_key("staff"):
+                    value = user["staff"]
+                    if value is True:
+                        ftok.write("STAFF=1\n")
+                if user.has_key("superuser"):
+                    value = user["superuser"]
+                    if value is True:
+                        ftok.write("SUPERUSER=1\n")
                 ftok.close()
         if section_name == "callback_tokens":
             for token in section:

--- a/tokens.yaml
+++ b/tokens.yaml
@@ -1,4 +1,9 @@
 lava_server_users:
+  - name: admin
+    token: longrandomtokenadmin
+    password: admin
+    superuser: yes
+    staff: yes
   - name: example
     token: longrandomtoken
     password: examplepassword


### PR DESCRIPTION
This patch add two user options staff and superuser.
This will permit to create users with thoses flag in LAVA.

In the process remove the hardcoded admin user from Dockerfile and move
it in tokens.yaml