### PR TITLE
stick to 2017.11

### DIFF
--- a/common/build-lava
+++ b/common/build-lava
@@ -1,0 +1,124 @@
+#!/bin/sh
+# This file is copied in {lava-master/lava-slave}/scripts
+
+if [ $# -le 1 ];then
+	echo "Build any LAVA compoments from source with specific version tag"
+	echo "Usage: $0 LAVAcompoment LAVA-git-tag LAVA-pkg-git-tag"
+	exit 1
+fi
+
+# common build deps
+DEBIAN_FRONTEND=noninteractive apt-get -y install python3-sphinx git devscripts || exit $?
+
+case $1 in
+lava-server)
+	# package dependencies
+	DEBIAN_FRONTEND=noninteractive apt-get -y install \
+	python-mock \
+	apache2 \
+	debootstrap \
+	ntfs-3g \
+	debhelper \
+	debootstrap \
+	libguestfs-tools \
+	build-essential \
+	docbook-xsl \
+	xsltproc \
+	gunicorn \
+	ntp \
+	nodejs \
+	node-uglify \
+	libjs-excanvas \
+	libjs-jquery-cookie \
+	libjs-jquery-watermark \
+	libjs-jquery-flot \
+	libjs-jquery-ui \
+	python-django \
+	python-json-schema-validator \
+	python-configglue \
+	python-twisted\
+	python-guestfs \
+	python-configobj \
+	python-lzma \
+	python-magic \
+	python-netifaces \
+	python-nose \
+	python-pexpect \
+	python-pyudev \
+	python-requests \
+	python-yaml \
+	python-zmq \
+	python3-sphinx-bootstrap-theme \
+	pep8 \
+	python-pep8 \
+	python-voluptuous \
+	python-dateutil \
+	python-django-auth-ldap \
+	python-django-restricted-resource \
+	python-django-tables2 \
+	python-docutils \
+	python-jinja2 \
+	python-markdown \
+	python-psycopg2 \
+	python-voluptuous \
+	python-sphinx \
+	python-sphinx-bootstrap-theme \
+	python-mocker \
+	systemd-sysv \
+	tftpd-hpa \
+	lxc \
+	sudo \
+	telnet \
+	bridge-utils || exit $?
+
+	DEBIAN_FRONTEND=noninteractive apt-get -y install lava-tool lavapdu-client lava-coordinator || exit $?
+;;
+lava-dispatcher)
+	# build dependencies
+	DEBIAN_FRONTEND=noninteractive apt-get -y install python-setuptools || exit $?
+	# package dependencies
+	DEBIAN_FRONTEND=noninteractive apt-get -y install python-serial \
+	python-daemon \
+	python-guestfs \
+	sudo \
+	telnet \
+	python-configobj \
+	python-lzma \
+	python-magic \
+	python-netifaces \
+	python-nose \
+	python-pexpect \
+	python-pyudev \
+	python-requests \
+	python-tz \
+	python-yaml \
+	python-zmq || exit $?
+;;
+*)
+	echo "Unknow compoments $1"
+	exit 1
+;;
+esac
+if [ ! -e /root/lava-server ];then
+	git clone https://github.com/Linaro/lava-server.git /root/lava-server || exit $?
+fi
+cd /root/lava-server
+git checkout $2 || exit $?
+
+if [ ! -e /root/$1 ];then
+	git clone https://github.com/Linaro/$1.git /root/$1 || exit $?
+fi
+cd /root/$1
+git checkout $2 || exit $?
+
+git config --global user.name "Docker Build"
+git config --global user.email "info@kernelci.org"
+
+# By default, debian-dev-build.sh use always the last tag as version
+sed -i "s,VERSION=.*,VERSION=$3," /root/lava-server/share/debian-dev-build.sh
+
+echo "cd \${DIR} && dpkg -i *.deb" >> /root/lava-server/share/debian-dev-build.sh
+
+cd /root/$1
+/root/lava-server/share/debian-dev-build.sh -p $1 -b $3
+exit $?

--- a/lava-master/Dockerfile
+++ b/lava-master/Dockerfile
@@ -29,36 +29,31 @@ RUN wget http://images.validation.linaro.org/production-repo/production-repo.key
  && echo 'deb http://images.validation.linaro.org/production-repo/ stretch-backports main' > /etc/apt/sources.list.d/lava.list \
  && apt-get clean && apt-get update
 
-RUN service postgresql start \
- && DEBIAN_FRONTEND=noninteractive apt-get -y install \
- lava \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
  qemu-system \
  qemu-system-arm \
  qemu-system-i386 \
  qemu-kvm \
  ser2net \
  u-boot-tools \
- python-setproctitle \
- && a2enmod proxy \
- && a2enmod proxy_http \
- && a2dissite 000-default \
- && a2ensite lava-server \
- && /stop.sh
+ python-setproctitle
+
+#RUN service postgresql start \
+# && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+# lava \
+# && /stop.sh
 
 # Install latest
-#RUN /start.sh \
-# && git clone https://github.com/kernelci/lava-dispatcher.git -b master  /root/lava-dispatcher \
-# && cd /root/lava-dispatcher \
-# && git checkout release \
-# && git clone -b master https://github.com/kernelci/lava-server.git /root/lava-server \
-# && cd /root/lava-server \
-# && git checkout release \
-# && git config --global user.name "Docker Build" \
-# && git config --global user.email "info@kernelci.org" \
-# && echo "cd \${DIR} && dpkg -i *.deb" >> /root/lava-server/share/debian-dev-build.sh \
-# && cd /root/lava-dispatcher && /root/lava-server/share/debian-dev-build.sh -p lava-dispatcher \
-# && cd /root/lava-server && /root/lava-server/share/debian-dev-build.sh -p lava-server \
-# && /stop.sh
+COPY scripts/build-lava /
+RUN bash /build-lava lava-dispatcher 2017.11 2017.11.post1-1
+RUN service postgresql start && \
+ bash /build-lava lava-server 2017.11 2017.11.post1-1 && \
+ /stop.sh
+
+RUN a2enmod proxy \
+ && a2enmod proxy_http \
+ && a2dissite 000-default \
+ && a2ensite lava-server
 
 COPY configs/tftpd-hpa /etc/default/tftpd-hpa
 

--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -13,9 +13,6 @@ RUN \
  echo 'locales locales/default_environment_locale select en_US.UTF-8' | debconf-set-selections && \
  DEBIAN_FRONTEND=noninteractive apt-get -y install \
  locales \
- lava-dispatcher \
- lava-dev \
- git \
  vim \
  sudo \
  cu \
@@ -31,23 +28,16 @@ RUN \
  xnbd-server \
  e2fsprogs
 
-RUN wget http://images.validation.linaro.org/production-repo/production-repo.key.asc \
- && apt-key add production-repo.key.asc \
- && echo 'deb http://images.validation.linaro.org/production-repo/ stretch-backports main' > /etc/apt/sources.list.d/lava.list \
- && apt-get clean && apt-get update
+# Uncomment the following for having the latest package (you need to comment all build-lava below)
+#RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget gnupg \
+# && wget http://images.validation.linaro.org/production-repo/production-repo.key.asc \
+# && apt-key add production-repo.key.asc \
+# && echo 'deb http://images.validation.linaro.org/production-repo/ stretch-backports main' > /etc/apt/sources.list.d/lava.list \
+# && apt-get clean && apt-get update
+#RUN DEBIAN_FRONTEND=noninteractive apt-get -y install lava-dispatcher
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install lava-dispatcher
-
-#RUN \
-# git clone https://github.com/kernelci/lava-server.git -b release /root/lava-server && \
-# git clone https://github.com/kernelci/lava-dispatcher.git -b master /root/lava-dispatcher && \
-# cd /root/lava-dispatcher && \
-# git checkout release && \
-# git config --global user.name "Docker Build" && \
-# git config --global user.email "info@kernelci.org" && \
-# echo "cd \${DIR} && dpkg -i *.deb" >> /root/lava-server/share/debian-dev-build.sh && \
-# sleep 2 && \
-# /root/lava-server/share/debian-dev-build.sh -p lava-dispatcher
+COPY scripts/build-lava /
+RUN sh /build-lava lava-dispatcher 2017.11 2017.11.post1-1
 
 COPY configs/lava-slave /etc/lava-dispatcher/lava-slave
 

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -7,6 +7,7 @@ import argparse
 import yaml
 import string
 import socket
+import shutil
 
 # Defaults
 boards_yaml = "boards.yaml"
@@ -146,6 +147,8 @@ def main(args):
         yaml.dump(dockcomp, f)
 
 if __name__ == "__main__":
+    shutil.copy("common/build-lava", "lava-slave/scripts/build-lava")
+    shutil.copy("common/build-lava", "lava-master/scripts/build-lava")
     parser = argparse.ArgumentParser()
     parser.add_argument("--header", help="use this file as header for output file")
     args = parser.parse_args()


### PR DESCRIPTION
Since LAVA packages are ephemeral, this patch permit to build a know release of LAVA.
In the same time, stick to 2017.11 as its a know working release for
lava-docker.