### PR TITLE
Hexid

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ This file describe how the DUTs are connected and powered.
 ```
 lab-slave-XX:		The name of the slave (where XX is a number)
   dispatcher_ip: the IP where the slave could be contacted. In lava-docker it is the host IP since docker proxify TFTP from host to the slave.
+  host_has_cpuflag_kvm: Does the host running lab-slave-XX have KVM
   boardlist:
     devicename:	Each board must be named by their device-type as "device-type-XX" (where XX is a number)
       type: the LAVA device-type of this device

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ lab-slave-XX:		The name of the slave (where XX is a number)
       macaddr: (Optional) the MAC address to set in uboot
 # One of uart or connection_command must be choosen
       uart:
-	idvendor: The VID of the UART
-	idproduct: the PID of the UART
+	idvendor: The VID of the UART (Formated as 0xXXXX)
+	idproduct: the PID of the UART (Formated as 0xXXXX)
         serial: The serial number in case of FTDI uart
         devpath: the UDEV devpath to this uart for UART without serial number
       connection_command: A command to be ran for getting a serial console

--- a/boards.yaml.example
+++ b/boards.yaml.example
@@ -10,8 +10,8 @@ lab-slave-0:
         power_off_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_off 1
         power_on_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_on 1
       uart:
-        idvendor: "0403"
-        idproduct: 6001
+        idvendor: 0x0403
+        idproduct: 0x6001
         serial: FT9QQZTA
     am335x-boneblack-01:
       type: beaglebone-black
@@ -20,8 +20,8 @@ lab-slave-0:
         power_off_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_off 2
         power_on_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_on 2
       uart:
-        idvendor: "0403"
-        idproduct: 6001
+        idvendor: 0x0403
+        idproduct: 0x6001
         serial: FT9QR1A9
     meson-gxl-s905x-libretech-cc-01:
       type: meson-gxl-s905x-libretech-cc
@@ -30,8 +30,8 @@ lab-slave-0:
         power_off_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_off 3
         power_on_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_on 3
       uart:
-        idvendor: 067b
-        idproduct: 2303
+        idvendor: 0x067b
+        idproduct: 0x2303
         devpath: 1.1.4
       macaddr: "00:FA:E0:DE:AD:78"
     dragonboard-410c-01:
@@ -41,8 +41,8 @@ lab-slave-0:
         power_off_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_off 4
         power_on_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_on 4
       uart:
-        idvendor: "0403"
-        idproduct: 6001
+        idvendor: 0x403
+        idproduct: 0x6001
         serial: FT9R7VDB
     r8a7796-m3ulcb-01:
       type: r8a7796-m3ulcb
@@ -51,8 +51,8 @@ lab-slave-0:
         power_off_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_off 5
         power_on_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_on 5
       uart:
-        idvendor: "0403"
-        idproduct: 6001
+        idvendor: 0x0403
+        idproduct: 0x6001
         serial: AK04WW0Q
     imx6q-sabrelite-01:
       type: imx6q-sabrelite
@@ -61,6 +61,6 @@ lab-slave-0:
         power_off_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_off 6
         power_on_command: /usr/local/bin/acme-cli -s 192.168.66.2 switch_on 6
       uart:
-        idvendor: "0403"
-        idproduct: 6015
+        idvendor: 0x0403
+        idproduct: 0x6015
         serial: DAZ0KEUH

--- a/docker-compose.template
+++ b/docker-compose.template
@@ -7,9 +7,6 @@ services:
     tty: true
     build:
       context: lava-master
-# TODO handle kvm option
-#    devices:
-#      - "/dev/kvm:/dev/kvm"
     ports:
       - "10080:80"
       - "5555:5555"
@@ -25,7 +22,6 @@ services:
     restart: always
     build:
       context: lava-slave
-    devices:
     environment:
       LAVA_MASTER: "lava-master"
     ports:

--- a/docker-compose.template
+++ b/docker-compose.template
@@ -18,7 +18,7 @@ services:
 # boot and /lib/modules are for libguestfs (TODO set them read_only with docker-compose 3.0)
       - "/boot:/boot"
       - "/lib/modules:/lib/modules"
-  lava-slave:
+  lab-slave-0:
     hostname: lab-slave-0
 #conmux does not support dns_search
     dns_search: ""

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -65,6 +65,16 @@ def main(args):
     for lab_name in labs:
         udev_line =""
         lab = labs[lab_name]
+        use_kvm = False
+        if lab.has_key("host_has_cpuflag_kvm"):
+            use_kvm = lab["host_has_cpuflag_kvm"]
+        if use_kvm:
+            if dockcomp["services"][lab_name].has_key("devices"):
+                dc_devices = dockcomp["services"][lab_name]["devices"]
+            else:
+                dockcomp["services"][lab_name]["devices"] = []
+                dc_devices = dockcomp["services"][lab_name]["devices"]
+            dc_devices.append("/dev/kvm:/dev/kvm")
         for board_name in lab["boardlist"]:
             b = lab["boardlist"][board_name]
             if b.get("disabled", None):
@@ -110,7 +120,7 @@ def main(args):
                 device_line += "{%% set fastboot_serial_number = '%s' %%}" % fserial
 
             # board specific hacks
-            if devicetype == "qemu":
+            if devicetype == "qemu" and not use_kvm:
                 device_line += "{% set no_kvm = True %}\n"
             if not os.path.isdir("lava-master/devices/"):
                 os.mkdir("lava-master/devices/")

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -92,13 +92,19 @@ def main(args):
                 baud = b["uart"].get("baud", baud_default)
                 idvendor = b["uart"]["idvendor"]
                 idproduct = b["uart"]["idproduct"]
+                if type(idproduct) == str:
+                    print("Please put hexadecimal IDs for product %s (like 0x%s)" % (board_name,idproduct))
+                    sys.exit(1)
+                if type(idvendor) == str:
+                    print("Please put hexadecimal IDs for vendor %s (like 0x%s)" % (board_name,idvendor))
+                    sys.exit(1)
                 line = template_conmux.substitute(board=board_name, baud=baud)
                 if "serial" in uart:
                     serial = b["uart"]["serial"]
-                    udev_line += template_udev_serial.substitute(board=board_name, serial=serial, idvendor=idvendor, idproduct=idproduct)
+                    udev_line += template_udev_serial.substitute(board=board_name, serial=serial, idvendor="%04x" % idvendor, idproduct="%04x" % idproduct)
                 else:
                     devpath = b["uart"]["devpath"]
-                    udev_line += template_udev_devpath.substitute(board=board_name, devpath=devpath, idvendor=idvendor, idproduct=idproduct)
+                    udev_line += template_udev_devpath.substitute(board=board_name, devpath=devpath, idvendor="%04x" % idvendor, idproduct="%04x" % idproduct)
                 if "devices" in dockcomp["services"][lab_name]:
                     dc_devices = dockcomp["services"][lab_name]["devices"]
                 else:

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -51,10 +51,6 @@ def main(args):
     tdc = open("docker-compose.template", "r")
     dockcomp = yaml.load(tdc)
     tdc.close()
-    dc_devices = dockcomp["services"]["lava-slave"]["devices"]
-    if dc_devices is None:
-        dockcomp["services"]["lava-slave"]["devices"] = []
-        dc_devices = dockcomp["services"]["lava-slave"]["devices"]
 
     # The slaves directory must exists
     if not os.path.isdir("lava-master/slaves/"):
@@ -93,6 +89,11 @@ def main(args):
                 else:
                     devpath = b["uart"]["devpath"]
                     udev_line += template_udev_devpath.substitute(board=board_name, devpath=devpath, idvendor=idvendor, idproduct=idproduct)
+                if dockcomp["services"][lab_name].has_key("devices"):
+                    dc_devices = dockcomp["services"][lab_name]["devices"]
+                else:
+                    dockcomp["services"][lab_name]["devices"] = []
+                    dc_devices = dockcomp["services"][lab_name]["devices"]
                 dc_devices.append("/dev/%s:/dev/%s" % (board_name, board_name))
                 fp = open("lava-slave/conmux/%s.cf" % board_name, "w")
                 fp.write(line)

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -66,10 +66,10 @@ def main(args):
         udev_line =""
         lab = labs[lab_name]
         use_kvm = False
-        if lab.has_key("host_has_cpuflag_kvm"):
+        if "host_has_cpuflag_kvm" in lab:
             use_kvm = lab["host_has_cpuflag_kvm"]
         if use_kvm:
-            if dockcomp["services"][lab_name].has_key("devices"):
+            if "devices" in dockcomp["services"][lab_name]:
                 dc_devices = dockcomp["services"][lab_name]["devices"]
             else:
                 dockcomp["services"][lab_name]["devices"] = []
@@ -82,24 +82,24 @@ def main(args):
 
             devicetype = b["type"]
             device_line = template_device.substitute(devicetype=devicetype)
-            if b.has_key("pdu_generic"):
+            if "pdu_generic" in b:
                 hard_reset_command = b["pdu_generic"]["hard_reset_command"]
                 power_off_command = b["pdu_generic"]["power_off_command"]
                 power_on_command = b["pdu_generic"]["power_on_command"]
                 device_line += template_device_pdu_generic.substitute(hard_reset_command=hard_reset_command, power_off_command=power_off_command, power_on_command=power_on_command)
-            if b.has_key("uart"):
+            if "uart" in b:
                 uart = b["uart"]
                 baud = b["uart"].get("baud", baud_default)
                 idvendor = b["uart"]["idvendor"]
                 idproduct = b["uart"]["idproduct"]
                 line = template_conmux.substitute(board=board_name, baud=baud)
-                if uart.has_key("serial"):
+                if "serial" in uart:
                     serial = b["uart"]["serial"]
                     udev_line += template_udev_serial.substitute(board=board_name, serial=serial, idvendor=idvendor, idproduct=idproduct)
                 else:
                     devpath = b["uart"]["devpath"]
                     udev_line += template_udev_devpath.substitute(board=board_name, devpath=devpath, idvendor=idvendor, idproduct=idproduct)
-                if dockcomp["services"][lab_name].has_key("devices"):
+                if "devices" in dockcomp["services"][lab_name]:
                     dc_devices = dockcomp["services"][lab_name]["devices"]
                 else:
                     dockcomp["services"][lab_name]["devices"] = []
@@ -109,13 +109,13 @@ def main(args):
                 fp.write(line)
                 fp.close()
                 device_line += template_device_conmux.substitute(board=board_name)
-            elif b.has_key("connection_command"):
+            elif "connection_command" in b:
                 connection_command = b["connection_command"]
                 device_line += template_device_connection_command.substitute(connection_command=connection_command)
-            if b.has_key("macaddr"):
+            if "macaddr" in b:
                 device_line += '{% set uboot_set_mac = true %}'
                 device_line += "{%% set uboot_mac_addr = '%s' %%}" % b["macaddr"]
-            if b.has_key("fastboot_serial_number"):
+            if "fastboot_serial_number" in b:
                 fserial = b["fastboot_serial_number"]
                 device_line += "{%% set fastboot_serial_number = '%s' %%}" % fserial
 
@@ -136,7 +136,7 @@ def main(args):
         fp = open("udev/99-lavalab-udev-%s.rules" % lab_name, "w")
         fp.write(udev_line)
         fp.close()
-        if lab.has_key("dispatcher_ip"):
+        if "dispatcher_ip" in lab:
             fp = open("lava-master/slaves/%s.yaml" % lab_name, "w")
             fp.write("dispatcher_ip: %s" % lab["dispatcher_ip"])
             fp.close()
@@ -157,15 +157,15 @@ def main(args):
                 ftok = open("lava-master/users/%s" % username, "w")
                 token = user["token"]
                 ftok.write("TOKEN=" + token + "\n")
-                if user.has_key("password"):
+                if "password" in user:
                     password = user["password"]
                     ftok.write("PASSWORD=" + password + "\n")
                 # libyaml convert yes/no to true/false...
-                if user.has_key("staff"):
+                if "staff" in user:
                     value = user["staff"]
                     if value is True:
                         ftok.write("STAFF=1\n")
-                if user.has_key("superuser"):
+                if "superuser" in user:
                     value = user["superuser"]
                     if value is True:
                         ftok.write("SUPERUSER=1\n")
@@ -181,7 +181,7 @@ def main(args):
                 description = token["description"]
                 ftok.write("DESCRIPTION=" + description)
                 ftok.close()
-    with file('docker-compose.yml', 'w') as f:
+    with open('docker-compose.yml', 'w') as f:
         yaml.dump(dockcomp, f)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fix the problem of malformated udev lines via two methods:
- prevent the use of string in idvendor/idproduct
- print the ID via "%04x"

This PR is based on top of enablekvm PR
This PR support also python3 for lavalab-gen.py