### PR TITLE
Fix "Remove tty/stdin options"

### DIFF
--- a/lava-master/Dockerfile
+++ b/lava-master/Dockerfile
@@ -77,4 +77,4 @@ COPY settings.conf /etc/lava-server/
 
 EXPOSE 69/udp 80 3079 5555 5556
 
-CMD /start.sh && bash
+CMD /start.sh && while [ true ];do sleep 365d; done


### PR DESCRIPTION
The commit "Remove tty/stdin options" miss a part of the changes, since Dockerfile still exec bash.

Remove bash and replace it with a forever sleep