### PR TITLE
lavalab-gen: add \n between custom options

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -345,7 +345,7 @@ def main():
             device_line += "{%% set fastboot_serial_number = '%s' %%}" % fserial
         if "custom_option" in board:
             for coption in board["custom_option"]:
-                device_line += "{%% %s %%}" % coption
+                device_line += "{%% %s %%}\n" % coption
         if not os.path.isdir(device_path):
             os.mkdir(device_path)
         if not os.path.isdir(devices_path):


### PR DESCRIPTION
If a board has mutliple custom options, they need to be separated by a newline.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>