### PR TITLE
lavalab-gen.py: token is optional for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ masters:
     persistent_db: True/False	(default False) Is the postgres DB is persistent over reboot
     users:
     - name: LAVA username
-      token: The token of this user
+      token: The token of this user 	(optional)
       password: Password the this user (generated if not provided)
       superuser: yes/no (default no)
       staff: yes/no (default no)

--- a/lava-master/scripts/setup.sh
+++ b/lava-master/scripts/setup.sh
@@ -29,6 +29,7 @@ if [ -e /root/lava-users ];then
 		USER_OPTION=""
 		STAFF=0
 		SUPERUSER=0
+		TOKEN=""
 		. /root/lava-users/$ut
 		if [ -z "$PASSWORD" -o "$PASSWORD" = "$TOKEN" ];then
 			echo "Generating password..."
@@ -48,6 +49,7 @@ if [ -e /root/lava-users ];then
 			echo "Adding username $USER DEBUG(with $TOKEN / $PASSWORD / $USER_OPTION)"
 			lava-server manage users add --passwd $PASSWORD $USER_OPTION $USER || exit 1
 			if [ ! -z "$TOKEN" ];then
+				echo "Adding token to user $USER"
 				lava-server manage tokens add --user $USER --secret $TOKEN || exit 1
 			fi
 		fi

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -159,8 +159,9 @@ def main():
                         print("WARNING: unknown keyword %s" % keyword)
                 username = user["name"]
                 ftok = open("%s/%s" % (userdir, username), "w")
-                token = user["token"]
-                ftok.write("TOKEN=" + token + "\n")
+                if "token" in user:
+                    token = user["token"]
+                    ftok.write("TOKEN=" + token + "\n")
                 if "password" in user:
                     password = user["password"]
                     ftok.write("PASSWORD=" + password + "\n")


### PR DESCRIPTION
This PR fix https://jira.automotivelinux.org/browse/SPEC-1603