### PR TITLE
Csrf fix

### DIFF
--- a/lava-master-base/scripts/lava-logs
+++ b/lava-master-base/scripts/lava-logs
@@ -41,7 +41,7 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   other if daemon could not be started or a failure occured
-	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec $DAEMON -- manage lava-logs --level $LOGLEVEL $SOCKET $MASTER_SOCKET $IPV6 $ENCRYPT $MASTER_CERT $SLAVES_CERTS
+	start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- manage lava-logs --level $LOGLEVEL $SOCKET $MASTER_SOCKET $IPV6 $ENCRYPT $MASTER_CERT $SLAVES_CERTS
 }
 
 do_stop()

--- a/lava-master-base/scripts/lava-server-gunicorn
+++ b/lava-master-base/scripts/lava-server-gunicorn
@@ -43,7 +43,7 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   other if daemon could not be started or a failure occured
-	start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec $DAEMON -- lava_server.wsgi --log-level $LOGLEVEL --log-file $LOGFILE -u lavaserver -g lavaserver --workers $WORKERS $RELOAD
+	start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON -- lava_server.wsgi --log-level $LOGLEVEL --log-file $LOGFILE -u lavaserver -g lavaserver --workers $WORKERS $RELOAD
 }
 
 do_stop()

--- a/lava-slave/scripts/setup.sh
+++ b/lava-slave/scripts/setup.sh
@@ -40,6 +40,14 @@ if [ -e /root/device-types ];then
 	done
 fi
 
+lavacli $LAVACLIOPTS device-types list > /tmp/device-types.list
+if [ $? -ne 0 ];then
+	exit 1
+fi
+lavacli $LAVACLIOPTS devices list -a > /tmp/devices.list
+if [ $? -ne 0 ];then
+	exit 1
+fi
 for worker in $(ls /root/devices/)
 do
 	lavacli $LAVACLIOPTS workers list |grep -q $worker
@@ -63,7 +71,7 @@ do
 			echo "Skip devicetype $devicetype"
 		else
 			echo "Add devicetype $devicetype"
-			lavacli $LAVACLIOPTS device-types list | grep -q "$devicetype[[:space:]]"
+			grep -q "$devicetype[[:space:]]" /tmp/device-types.list
 			if [ $? -eq 0 ];then
 				echo "Skip devicetype $devicetype"
 			else
@@ -72,7 +80,7 @@ do
 			touch /root/.lavadocker/devicetype-$devicetype
 		fi
 		echo "Add device $devicename on $worker"
-		lavacli $LAVACLIOPTS devices list -a | grep -q $devicename
+		grep -q "$devicename[[:space:]]" /tmp/devices.list
 		if [ $? -eq 0 ];then
 			echo "$devicename already present"
 			#verify if present on another worker

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -68,6 +68,7 @@ template_settings_conf = string.Template("""
     "HTTPS_XML_RPC": false,
     "LOGIN_URL": "/accounts/login/",
     "LOGIN_REDIRECT_URL": "/",
+    "CSRF_TRUSTED_ORIGINS": ["$lava_http_fqdn"],
     "CSRF_COOKIE_SECURE": $cookie_secure,
     "SESSION_COOKIE_SECURE": $session_cookie_secure
 }
@@ -146,7 +147,7 @@ def main():
         f_fqdn.write(lava_http_fqdn)
         f_fqdn.close()
         fsettings = open("%s/settings.conf" % workerdir, 'w')
-        fsettings.write(template_settings_conf.substitute(cookie_secure=cookie_secure, session_cookie_secure=session_cookie_secure))
+        fsettings.write(template_settings_conf.substitute(cookie_secure=cookie_secure, session_cookie_secure=session_cookie_secure, lava_http_fqdn=lava_http_fqdn))
         fsettings.close()
         master_use_zmq_auth = False
         if "zmq_auth" in worker:


### PR DESCRIPTION
This PR fix the CSRF problem reported by AGL.
It uses the already present lava_http_fqdn boards.yaml option for filling CSRF_TRUSTED_ORIGINS

This PR fix also init scripts which cannot restart correctly services.