### PR TITLE
lava-slave: increase connect to master timeout

### DIFF
--- a/lava-slave/scripts/setup.sh
+++ b/lava-slave/scripts/setup.sh
@@ -15,17 +15,18 @@ cd /root/lavacli
 LAVACLIOPTS="--uri $LAVA_MASTER_URI"
 
 # do a sort of ping for letting master to be up
-TIMEOUT=30
+TIMEOUT=300
 while [ $TIMEOUT -ge 1 ];
 do
+	STEP=2
 	lavacli $LAVACLIOPTS device-types list 2>/dev/null >/dev/null
 	if [ $? -eq 0 ];then
 		TIMEOUT=0
 	else
 		echo "Wait for master...."
-		sleep 2	
+		sleep $STEP
 	fi
-	TIMEOUT=$(($TIMEOUT-1))
+	TIMEOUT=$(($TIMEOUT-$STEP))
 done
 
 # This directory is used for storing device-types already added


### PR DESCRIPTION
When trying to detect if master is up, we have set a timeout of 60s.
This is good for most of the time, but when the master is restoring a
database, 60s is not enougth.
This patch increase timeout to 300s.