### PR TITLE
lava-slave/scripts: fix master key name

### DIFF
--- a/lava-slave/scripts/setup.sh
+++ b/lava-slave/scripts/setup.sh
@@ -120,6 +120,6 @@ if [ -e /etc/lava-dispatcher/certificates.d/$(hostname).key ];then
 	echo "INFO: Enabling encryption"
 	sed -i 's,.*ENCRYPT=.*,ENCRYPT="--encrypt",' /etc/lava-dispatcher/lava-slave
 	sed -i "s,.*SLAVE_CERT=.*,SLAVE_CERT=\"--slave-cert /etc/lava-dispatcher/certificates.d/$(hostname).key_secret\"," /etc/lava-dispatcher/lava-slave
-	sed -i "s,.*MASTER_CERT=.*,MASTER_CERT=\"--master-cert /etc/lava-dispatcher/certificates.d/$LAVA_MASTER.key\"," /etc/lava-dispatcher/lava-slave
+	sed -i "s,.*MASTER_CERT=.*,MASTER_CERT=\"--master-cert /etc/lava-dispatcher/certificates.d/master.key\"," /etc/lava-dispatcher/lava-slave
 fi
 exit 0


### PR DESCRIPTION
The ZMQ auth scripts are copying the master key to the slave config
with a hard-coded file name: master.key.  Yet the lava-slave config
file was looking for $LAVA_MASTER.key.

This caused the slave to fail to find the key and abort startup.

Fix by using the same hard-coded filename in the lava-slave config.