### PR TITLE
lavalab-gen: fiz zmq key filename assumptions

### DIFF
--- a/lava-slave/scripts/setup.sh
+++ b/lava-slave/scripts/setup.sh
@@ -120,6 +120,7 @@ if [ -e /etc/lava-dispatcher/certificates.d/$(hostname).key ];then
 	echo "INFO: Enabling encryption"
 	sed -i 's,.*ENCRYPT=.*,ENCRYPT="--encrypt",' /etc/lava-dispatcher/lava-slave
 	sed -i "s,.*SLAVE_CERT=.*,SLAVE_CERT=\"--slave-cert /etc/lava-dispatcher/certificates.d/$(hostname).key_secret\"," /etc/lava-dispatcher/lava-slave
+	(cd /etc/lava-dispatcher/certificates.d; if [ -e master.key ]; then cp master.key $LAVA_MASTER.key; fi)
 	sed -i "s,.*MASTER_CERT=.*,MASTER_CERT=\"--master-cert /etc/lava-dispatcher/certificates.d/$LAVA_MASTER.key\"," /etc/lava-dispatcher/lava-slave
 fi
 exit 0

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -156,8 +156,8 @@ def main():
             master_use_zmq_auth = worker["zmq_auth"]
         if master_use_zmq_auth:
             if "zmq_auth_key" in worker:
-                shutil.copy(worker["zmq_auth_key"], "%s/zmq_auth/" % workerdir)
-                shutil.copy(worker["zmq_auth_key_secret"], "%s/zmq_auth/" % workerdir)
+                shutil.copy(worker["zmq_auth_key"], "%s/zmq_auth/%s.key" % (workerdir, name))
+                shutil.copy(worker["zmq_auth_key_secret"], "%s/zmq_auth/%s.key_secret" % (workerdir, name))
             else:
                 zmq_auth_genlist.write("%s/%s\n" % (host, name))
                 need_zmq_auth_gen = True
@@ -294,12 +294,12 @@ def main():
                     master_use_zmq_auth = fm["zmq_auth"]
                 if master_use_zmq_auth:
                     if "zmq_auth_key" in fm:
-                        shutil.copy(fm["zmq_auth_key"], "%s/zmq_auth/" % workerdir)
+                        shutil.copy(fm["zmq_auth_key"], "%s/zmq_auth/%s.key" % (workerdir, remote_address))
                     if "zmq_auth_key" in worker:
-                        shutil.copy(worker["zmq_auth_key"], "%s/zmq_auth/" % workerdir)
-                        shutil.copy(worker["zmq_auth_key_secret"], "%s/zmq_auth/" % workerdir)
+                        shutil.copy(worker["zmq_auth_key"], "%s/zmq_auth/%s.key" % (workerdir, name))
+                        shutil.copy(worker["zmq_auth_key_secret"], "%s/zmq_auth/%s.key_secret" % (workerdir, name))
                         if "zmq_auth_key" in fm:
-                            shutil.copy(worker["zmq_auth_key"], "output/%s/%s/zmq_auth/" % (fm["host"], fm["name"]))
+                            shutil.copy(worker["zmq_auth_key"], "output/%s/%s/zmq_auth/%s.key" % (fm["host"], fm["name"], name))
                     else:
                         zmq_auth_genlist.write("%s/%s %s/%s\n" % (host, name, fm["host"], fm["name"]))
                         need_zmq_auth_gen = True


### PR DESCRIPTION
The ZMQ key file names are expected to have specific names in the
containers (e.g. $LAVA_MASTER.key).  However, when using existing key
files, they are simply copied into the containers, and if they don't
match the exact requirements, encryption will silently fail.

Fix this by allowing arbitrary filenames for existing keys, but ensure
they are copied into the container with the expected filenames.

Related, when using auto-generated keys, the generated master key is
simply "master.key" in the slave.  Fix this by ensuring that
"master.key" is copied to $LAVA_MASTER.key when the slave container
starts.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>