### PR TITLE
README: enhance documentation on dependencies and CSRF issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ lava-docker has currently been tested primarily on Debian stable (stretch).
 The following packages are necessary on the host machine:
 * docker
 * docker-compose
+* pyyaml
 
 ## Quickstart
 Example to use lava-docker with only one QEMU device:
@@ -219,7 +220,7 @@ masters:
     zmq_auth_key:		optional path to a public ZMQ key
     zmq_auth_key_secret:	optional path to a private ZMQ key
     persistent_db: True/False	(default False) Is the postgres DB is persistent over reboot
-    http_fqdn:			The FQDN used to access the LAVA web interface
+    http_fqdn:			The FQDN used to access the LAVA web interface. This is necessary if you use https otherwise you will issue CSRF errors.
     users:
     - name: LAVA username
       token: The token of this user 	(optional)

--- a/README.md
+++ b/README.md
@@ -359,3 +359,11 @@ Note that this container provides defaults which are unsecure. If you plan on de
   * Changing the default admin password (in tokens.taml)
   * Using HTTPS
   * Re-enable CSRF cookie (disabled in lava-master/Dockerfile)
+
+## Non amd64 build
+Since LAVA upstream provides only amd64 and arm64 debian packages, lava-docker support only thoses architectures.
+For building an arm64 lava-docker, some little trick are necesssary:
+- replace "baylibre/lava-xxxx-base" by "baylibre/lava-xxxx-base-arm64" for lava-master and lava-slave dockerfiles
+
+For building lava-xxx-base images
+- replace "bitnami/minideb" by "arm64v8/debian" on lava-master-base/lava-slave-base dockerfiles.

--- a/lava-master/Dockerfile
+++ b/lava-master/Dockerfile
@@ -18,7 +18,6 @@ COPY scripts/setup.sh /
 # warning the address used must be network accessible by all slave
 #RUN sed -i 's,^.*http_proxy:.*,  http_proxy: http://squid:3128,' /etc/lava-server/env.yaml
 
-#comment this if you do HTTPS (For reenabling CSRF cookie)
 COPY settings.conf /etc/lava-server/
 
 COPY device-types-patch/ /root/device-types-patch/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+docker
+docker-compose
+pyyaml


### PR DESCRIPTION
This patch add the missing pyyaml requirement in the documentation,
fixing issue #31 in the process.
Note that this patch adds also a requirements.txt for easy pip install.

This patch also a note on http_fqdn stating this option as necessary
when using https.