### PR TITLE
lavalab-gen.sh: Handle arguments

### DIFF
--- a/lavalab-gen.sh
+++ b/lavalab-gen.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-rm -f lava-master/scripts/build-lava
-rm -f lava-slave/scripts/build-lava
 rm -rf output
 
 if [ "$1" = "mrproper" ];then
 	exit 0
 fi
 
-./lavalab-gen.py || exit 1
+./lavalab-gen.py $* || exit 1


### PR DESCRIPTION
This patch mades lavalab-gen.sh pass all arguments to lavalab-gen.py
Cleaning in the process the non-needed "rm build-lava"