### PR TITLE
lavalab-gen.py: Remove udev template for support of interfacenum

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ boards:
       idproduct: the PID of the UART (Formated as 0xXXXX)
       serial: The serial number in case of FTDI uart
       devpath: the UDEV devpath to this uart for UART without serial number
+      interfacenum:	(optional) The interfacenumber of the serial. (Used with two serial in one device)
       use_ser2net: True/false (Use ser2net instead of conmux-console)
       use_screen: True/false (Use screen via ssh instead of conmux-console)
     connection_command: A command to be ran for getting a serial console

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -249,7 +249,7 @@ def main():
                 envdir = "%s/env/%s" % (workerdir, slavename)
                 os.mkdir(envdir)
                 fenv = open("%s/env.yaml" % envdir, 'w')
-                fenv.write("overrides:")
+                fenv.write("overrides:\n")
                 for line in slaveenv["env"]:
                     fenv.write("  %s\n" % line)
                 fenv.close()
@@ -364,7 +364,7 @@ def main():
             envdir = "output/%s/%s/env/%s" % (slave_master["host"], slave_master["name"], name)
             os.mkdir(envdir)
             fenv = open("%s/env.yaml" % envdir, 'w')
-            fenv.write("overrides:")
+            fenv.write("overrides:\n")
             for line in slave["env"]:
                 fenv.write("  %s\n" % line)
             fenv.close()


### PR DESCRIPTION
The current udev templating is bad since adding a new optional keyword
lead to numerous ifelse and templates.

This patch simply generate a udev line part by part.
This made adding interfacenum easier.