### PR TITLE
lavalab-gen.py: Remove udev template for support of interfacenum

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ boards:
       idproduct: the PID of the UART (Formated as 0xXXXX)
       serial: The serial number in case of FTDI uart
       devpath: the UDEV devpath to this uart for UART without serial number
+      interfacenum:	(optional) The interfacenumber of the serial. (Used with two serial in one device)
       use_ser2net: True/false (Use ser2net instead of conmux-console)
       use_screen: True/false (Use screen via ssh instead of conmux-console)
     connection_command: A command to be ran for getting a serial console


### PR DESCRIPTION
The current udev templating is bad since adding a new optional keyword
lead to numerous ifelse and templates.

This patch simply generate a udev line part by part.
This made adding interfacenum easier.

This will also permit to mix devpath/serial/etc.. without any problem