### PR TITLE
lavalab-gen.py: Made ser2net the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,12 @@ boards:
       serial: The serial number in case of FTDI uart
       devpath: the UDEV devpath to this uart for UART without serial number
       interfacenum:	(optional) The interfacenumber of the serial. (Used with two serial in one device)
-      use_ser2net: True/false (Use ser2net instead of conmux-console)
+      use_conmux:	True/False (Use conmux-console instead of ser2net)
+      use_ser2net: 	True/False (Deprecated, ser2net is the default uart handler)
       ser2net_options	(optional) A list of ser2net options to add
         - option1
         - option2
-      use_screen: True/false (Use screen via ssh instead of conmux-console)
+      use_screen: 	True/False (Use screen via ssh instead of ser2net)
     connection_command: A command to be ran for getting a serial console
     pdu_generic:
       hard_reset_command: commandline to reset the board
@@ -312,7 +313,7 @@ Bus 001 Device 054: ID 0403:6001 Future Technology Devices International, Ltd FT
 ```
 This device must use "0403" for idvendor and 6001 for idproduct.
 
-Note on connection_command: connection_command is for people which want to use other way than conmux to handle the console. (ser2net).
+Note on connection_command: connection_command is for people which want to use other custom way than ser2net to handle the console.
 
 Examples: see [boards.yaml.example](boards.yaml.example)
 

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -464,15 +464,18 @@ def main():
                 dc_devices = dockcomp["services"][worker_name]["devices"]
             if not "bind_dev" in slave:
                 dc_devices.append("/dev/%s:/dev/%s" % (board_name, board_name))
-            use_conmux = True
-            use_ser2net = False
+            use_conmux = False
+            use_ser2net = True
             use_screen = False
-            if "use_ser2net" in uart:
-                use_conmux = False
-                use_ser2net = True
             if "use_screen" in uart:
-                use_conmux = False
-                use_screen = True
+                use_screen = uart["use_screen"]
+            if "use_conmux" in uart:
+                use_conmux = uart["use_conmux"]
+            if "use_ser2net" in uart:
+                use_ser2net = uart["use_ser2net"]
+            if (use_conmux and use_ser2net) or (use_conmux and use_screen) or (use_screen and use_ser2net):
+                print("ERROR: Only one uart handler must be configured")
+                sys.exit(1)
             if use_conmux:
                 conmuxline = template_conmux.substitute(board=board_name, baud=baud)
                 device_line += template_device_conmux.substitute(board=board_name)


### PR DESCRIPTION
This patch makes ser2net the default uart handler.