### PR TITLE
Use lavacli from package instead of from sources

### DIFF
--- a/lava-master-base/99-stretch-backports
+++ b/lava-master-base/99-stretch-backports
@@ -33,3 +33,7 @@ Pin-Priority: 500
 Package: lava-server-doc
 Pin: release n=stretch-backports
 Pin-Priority: 500
+
+Package: lavacli
+Pin: release n=stretch-backports
+Pin-Priority: 500

--- a/lava-slave-base/99-stretch-backports
+++ b/lava-slave-base/99-stretch-backports
@@ -17,3 +17,7 @@ Pin-Priority: 500
 Package: lava-dispatcher
 Pin: release n=stretch-backports
 Pin-Priority: 500
+
+Package: lavacli
+Pin: release n=stretch-backports
+Pin-Priority: 500

--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -30,9 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install ser2net
 RUN rm /etc/apt/sources.list.d/sid.list
 RUN apt-get update
 
-# lava-cli dependencies
-RUN apt-get -y install python3-setuptools python3-dev python3-zmq
-RUN git clone https://git.linaro.org/lava/lavacli.git /root/lavacli && cd /root/lavacli && git checkout v0.7 && python3 setup.py install
+RUN apt-get -y install lavacli
 
 COPY phyhostname /root/
 COPY scripts/setup.sh .


### PR DESCRIPTION
A recent enough lavacli is present on stretch-backports.
It is better to use it.
This will fix also some commands not working with recent LAVA server.