### PR TITLE
Use 2018.11

### DIFF
--- a/lava-master/Dockerfile
+++ b/lava-master/Dockerfile
@@ -1,4 +1,4 @@
-FROM baylibre/lava-master-base:latest
+FROM baylibre/lava-master-base:2018.11-1_bpo9_1
 
 COPY backup /root/backup/
 

--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM baylibre/lava-slave-base:latest
+FROM baylibre/lava-slave-base:2018.11-1_bpo9_1
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install cu conmux
 


### PR DESCRIPTION
This patch made lava-docker use a known to work dockerhub tag.
Keep the latest tag for internal work.