### PR TITLE
lavalab-gen: more flexible custom_options

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -533,8 +533,12 @@ def main():
             deviceinfo.write("DEVICE_GROUP=%s\n" % board["group"])
             deviceinfo.close()
         if "custom_option" in board:
-            for coption in board["custom_option"]:
-                device_line += "{%% %s %%}\n" % coption
+            if type(board["custom_option"]) == list:
+                for coption in board["custom_option"]:
+                    device_line += "{%% %s %%}\n" % coption
+            else:
+                for line in board["custom_option"].splitlines():
+                    device_line += "{%% %s %%}\n" % line
         if not os.path.isdir(device_path):
             os.mkdir(device_path)
         if not os.path.isdir(devices_path):


### PR DESCRIPTION
Adding custom options for LAVA often requires specific formatting for
the LAVA jinja2 files, including single or double quotes.  Rather than
also using quotes in the boards.yaml file, use YAML "plain style"[1]
avoids the need to add extra quotes or escapes.

When using the "|-" for plain style, the custom_options will appear to
lavalab-gen as a one long string, rather than a list of options, so
here we modify lavalab-gen to handle strings slightly differently than
a list.

[1] https://yaml.org/spec/1.2/spec.html#id2788859

Signed-off-by: Kevin Hilman <khilman@baylibre.com>