### PR TITLE
Install PXE stuff at runtime

### DIFF
--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -41,8 +41,7 @@ RUN apt-get -y install lavacli
 RUN if [ $(uname -m) != amd64 ]; then dpkg --add-architecture amd64 && apt-get update; fi
 RUN apt-get -y install grub-efi-amd64-bin:amd64
 RUN if [ $(uname -m) != amd64 ]; then dpkg --remove architecture amd64 && apt-get update; fi
-RUN cd /var/lib/lava/dispatcher/tmp && grub-mknetdir --net-directory=.
-COPY grub.cfg /var/lib/lava/dispatcher/tmp/boot/grub/
+COPY grub.cfg /root/
 
 COPY default/* /etc/default/
 

--- a/lava-slave/scripts/setup.sh
+++ b/lava-slave/scripts/setup.sh
@@ -10,6 +10,12 @@ if [ -z "$LAVA_MASTER_URI" ];then
 	exit 11
 fi
 
+# Install PXE
+OPWD=$(pwd)
+cd /var/lib/lava/dispatcher/tmp && grub-mknetdir --net-directory=.
+cp /root/grub.cfg /var/lib/lava/dispatcher/tmp/boot/grub/
+cd $OPWD
+
 lavacli identities add --uri $LAVA_MASTER_BASEURI --token $LAVA_MASTER_TOKEN --username $LAVA_MASTER_USER default
 
 echo "Dynamic slave for $LAVA_MASTER ($LAVA_MASTER_URI)"


### PR DESCRIPTION
When /var/lib/lava/dispatcher/tmp is a volume (like when using NFS), it
masks all PXE stuff installed during the build.

For preventing this, this patchs made this data installed at runtime.