### PR TITLE
Fix format of env.yaml

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -275,7 +275,7 @@ def main():
                 fenv = open("%s/env.yaml" % envdir, 'w')
                 fenv.write("overrides:\n")
                 for line in slaveenv["env"]:
-                    fenv.write("  %s\n" % line)
+                    fenv.write("  %s" % yaml.dump(line, default_flow_style=False))
                 fenv.close()
         if "loglevel" in worker:
             for component in worker["loglevel"]:
@@ -409,7 +409,7 @@ def main():
             fenv = open("%s/env.yaml" % envdir, 'w')
             fenv.write("overrides:\n")
             for line in slave["env"]:
-                fenv.write("  %s\n" % line)
+                fenv.write("  %s" % yaml.dump(line, default_flow_style=False))
             fenv.close()
         if not "remote_proto" in worker:
             remote_proto = "http"


### PR DESCRIPTION
The contents of the generated env.yaml is dictionary format, not YAML.
This fix the output to YAML.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro1.iwamatsu@toshiba.co.jp>