### PR TITLE
lavalab-gen.py: introduce SFTP/SSHFS mount support in Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ slaves:
     use_nbd:			Does LAVA need a NBD server (default True)
     use_overlay_server:		Does LAVA need an overlay server (default True)
     use_nfs:			Does the LAVA dispatcher will run NFS jobs
+    use_sshfs:			'true' if the LAVA dispatcher needs to mount a SSHFS volume
     use_tap:			Does TAP netdevices could be used
     arch:			The arch of the worker (if not x86_64), only accept arm64
     host_healthcheck:		If true, enable the optional healthcheck container. See hosting healthchecks below
@@ -476,6 +477,19 @@ EXample for an upsquare and a dispatcher availlable at 192.168.66.1:
 		next-server 192.168.66.1;
 	}
 ```
+
+## How to mount a SSHFS volume in the LAVA slave
+lava-docker automates the mounting of an existing SSHFS installation into the docker container.
+
+Setup:
+- Install SSHFS on the host
+- Configure SSHFS to use /media/sshfs_mnt/ as the mount point on the host.
+
+lava-docker usage:
+- Set use_sshfs 'true' in the slave section of the boards.yaml
+- docker-compose will be configured to mount /media/sshfs_mnt/ on the host into the same path within the container.
+
+If you wish to use different paths please modify the paths specified in lavalab-gen.py
 
 ## How to host healthchecks
 Healthchecks jobs needs externals ressources (rootfs, images, etc...).

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -364,7 +364,7 @@ def main():
     else:
         slaves = workers["slaves"]
     for slave in slaves:
-        keywords_slaves = [ "name", "host", "dispatcher_ip", "remote_user", "remote_master", "remote_address", "remote_rpc_port", "remote_proto", "extra_actions", "zmq_auth_key", "zmq_auth_key_secret", "default_slave", "export_ser2net", "expose_ser2net", "remote_user_token", "zmq_auth_master_key", "expose_ports", "env", "bind_dev", "loglevel", "use_nfs", "arch", "devices", "lava-coordinator", "use_tap", "host_healthcheck", "use_tftp", "use_nbd", "use_overlay_server", "tags" ]
+        keywords_slaves = [ "name", "host", "dispatcher_ip", "remote_user", "remote_master", "remote_address", "remote_rpc_port", "remote_proto", "extra_actions", "zmq_auth_key", "zmq_auth_key_secret", "default_slave", "export_ser2net", "expose_ser2net", "remote_user_token", "zmq_auth_master_key", "expose_ports", "env", "bind_dev", "loglevel", "use_nfs", "arch", "devices", "lava-coordinator", "use_tap", "host_healthcheck", "use_tftp", "use_nbd", "use_overlay_server", "tags", "use_sshfs" ]
         for keyword in slave:
             if not keyword in keywords_slaves:
                 print("WARNING: unknown keyword %s" % keyword)
@@ -559,6 +559,11 @@ def main():
             fp.write("apt-get -y install nfs-kernel-server\n")
             fp.close()
             os.chmod("%s/scripts/extra_actions" % workerdir, 0o755)
+        use_sshfs = False
+        if "use_sshfs" in worker:
+            use_sshfs = worker["use_sshfs"]
+        if use_sshfs:
+            dockcomp["services"][worker_name]["volumes"].append("/media/sshfs_mnt:/media/sshfs_mnt")
         with open(dockcomposeymlpath, 'w') as f:
             yaml.dump(dockcomp, f)
         if "loglevel" in worker:


### PR DESCRIPTION
Hi,

A couple of weeks ago I asked on IRC for feedback on how I was considering to add SFTP/SSHFS support to the Worker. The advice I got was to post a PR and here it is.

In my specific case I am administrating the Worker only. The task was limited to overcoming the issue of mount point handling in the volumes section of the docker-compose.

Tested as working on lava-docker commit b9e4d31 and rebased here for the PR to current master tip.

Regards

Steve