### PR TITLE
Permit to use docker commands in slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ slaves:
     use_overlay_server:		Does LAVA need an overlay server (default True)
     use_nfs:			Does the LAVA dispatcher will run NFS jobs
     use_tap:			Does TAP netdevices could be used
+    use_docker:			Permit to use docker commands in slave
     arch:			The arch of the worker (if not x86_64), only accept arm64
     host_healthcheck:		If true, enable the optional healthcheck container. See hosting healthchecks below
     lava-coordinator:		Does the slave should ran a lava-coordinator

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -364,7 +364,7 @@ def main():
     else:
         slaves = workers["slaves"]
     for slave in slaves:
-        keywords_slaves = [ "name", "host", "dispatcher_ip", "remote_user", "remote_master", "remote_address", "remote_rpc_port", "remote_proto", "extra_actions", "zmq_auth_key", "zmq_auth_key_secret", "default_slave", "export_ser2net", "expose_ser2net", "remote_user_token", "zmq_auth_master_key", "expose_ports", "env", "bind_dev", "loglevel", "use_nfs", "arch", "devices", "lava-coordinator", "use_tap", "host_healthcheck", "use_tftp", "use_nbd", "use_overlay_server", "tags" ]
+        keywords_slaves = [ "name", "host", "dispatcher_ip", "remote_user", "remote_master", "remote_address", "remote_rpc_port", "remote_proto", "extra_actions", "zmq_auth_key", "zmq_auth_key_secret", "default_slave", "export_ser2net", "expose_ser2net", "remote_user_token", "zmq_auth_master_key", "expose_ports", "env", "bind_dev", "loglevel", "use_nfs", "arch", "devices", "lava-coordinator", "use_tap", "host_healthcheck", "use_tftp", "use_nbd", "use_overlay_server", "tags", "use_docker" ]
         for keyword in slave:
             if not keyword in keywords_slaves:
                 print("WARNING: unknown keyword %s" % keyword)
@@ -539,6 +539,11 @@ def main():
             use_tftp = worker["use_tftp"]
         if use_tftp:
             dockcomp["services"][name]["ports"].append("69:69/udp")
+        use_docker = False
+        if "use_docker" in worker:
+            use_docker = worker["use_docker"]
+        if use_docker:
+            dockcomp["services"][worker_name]["volumes"].append("/var/run/docker.sock:/var/run/docker.sock")
         # TODO permit to change the range of NBD ports
         use_nbd = True
         if "use_nbd" in worker:


### PR DESCRIPTION
When docker devices are needed, docker socket must be availlable in the
slave.
This is now possible via the new use_docker