### PR TITLE
Improve backup handling

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -24,7 +24,8 @@ docker exec -ti $DOCKERID gzip /tmp/db_lavaserver || exit $?
 docker cp $DOCKERID:/tmp/db_lavaserver.gz $BACKUP_DIR/ || exit $?
 docker exec -ti $DOCKERID rm /tmp/db_lavaserver.gz || exit $?
 
-docker exec -ti $DOCKERID tar czf /root/joboutput.tar.gz /var/lib/lava-server/default/media/job-output/ || exit $?
+# tar outputs warnings when file changes on disk while creating tar file. So do not "exit on error"
+docker exec -ti $DOCKERID tar czf /root/joboutput.tar.gz /var/lib/lava-server/default/media/job-output/ || echo "WARNING: tar operation returned $?"
 docker cp $DOCKERID:/root/joboutput.tar.gz $BACKUP_DIR/ || exit $?
 docker exec -ti $DOCKERID rm /root/joboutput.tar.gz || exit $?
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
 BACKUP_DIR="backup-$(date +%Y%m%d_%H%M)"
+# use /tmp by default on host (this is used by tar)
+TMPDIR=${TMPDIR:-/tmp}
+export TMPDIR
+
+mkdir -p $TMPDIR
 
 mkdir $BACKUP_DIR
 cp boards.yaml $BACKUP_DIR

--- a/backup.sh
+++ b/backup.sh
@@ -15,19 +15,19 @@ if [ -z "$DOCKERID" ];then
 	exit 1
 fi
 
-docker exec -ti $DOCKERID tar czf /root/devices.tar.gz /etc/lava-server/dispatcher-config/devices/ || exit $?
+docker exec -t $DOCKERID tar czf /root/devices.tar.gz /etc/lava-server/dispatcher-config/devices/ || exit $?
 docker cp $DOCKERID:/root/devices.tar.gz $BACKUP_DIR/ || exit $?
 
 # for an unknown reason pg_dump > file doesnt work
-docker exec -ti $DOCKERID sudo -u postgres pg_dump --create --clean lavaserver --file /tmp/db_lavaserver || exit $?
-docker exec -ti $DOCKERID gzip /tmp/db_lavaserver || exit $?
+docker exec -t $DOCKERID sudo -u postgres pg_dump --create --clean lavaserver --file /tmp/db_lavaserver || exit $?
+docker exec -t $DOCKERID gzip /tmp/db_lavaserver || exit $?
 docker cp $DOCKERID:/tmp/db_lavaserver.gz $BACKUP_DIR/ || exit $?
-docker exec -ti $DOCKERID rm /tmp/db_lavaserver.gz || exit $?
+docker exec -t $DOCKERID rm /tmp/db_lavaserver.gz || exit $?
 
 # tar outputs warnings when file changes on disk while creating tar file. So do not "exit on error"
-docker exec -ti $DOCKERID tar czf /root/joboutput.tar.gz /var/lib/lava-server/default/media/job-output/ || echo "WARNING: tar operation returned $?"
+docker exec -t $DOCKERID tar czf /root/joboutput.tar.gz /var/lib/lava-server/default/media/job-output/ || echo "WARNING: tar operation returned $?"
 docker cp $DOCKERID:/root/joboutput.tar.gz $BACKUP_DIR/ || exit $?
-docker exec -ti $DOCKERID rm /root/joboutput.tar.gz || exit $?
+docker exec -t $DOCKERID rm /root/joboutput.tar.gz || exit $?
 
 echo "Backup done in $BACKUP_DIR"
 rm -f backup-latest

--- a/lava-master/entrypoint.d/01_setup.sh
+++ b/lava-master/entrypoint.d/01_setup.sh
@@ -17,6 +17,10 @@ if [ -e /root/backup/db_lavaserver ];then
 	yes yes | lava-server manage migrate || exit $?
 	echo "Restore jobs output from backup"
 	rm -r /var/lib/lava-server/default/media/job-output/*
+
+        # allow using different folder for tar operations (/tmp by default)
+        TMPDIR=${TMPDIR:-/tmp}
+
 	tar xzf /root/backup/joboutput.tar.gz || exit $?
 fi
 


### PR DESCRIPTION
I faced several problems with the backup once it reached > 3GB.
This is related to tar, which uses /tmp by default. And the size of /tmp is limited on some systems.
So I fixed that by allowing to change tar work folder (through TMPDIR variable)
