### PR TITLE
README.md: Correction / improvement to ser2net documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ Example:
 Bus 001 Device 054: ID 0403:6001 Future Technology Devices International, Ltd FT232 Serial (UART) IC
 ```
 This device must use "0403" for idvendor and 6001 for idproduct.
+* Some boards reset serial on power on. This can cause ser2net/telnet to disconnect resulting in the LAVA Worker being unable to program the board. This may be mitigated by passing LOCAL as an option to ser2net in the boards.yaml.
+Example:
+```
+      ser2net_options:
+        - LOCAL
+```
 
 Note on connection_command: connection_command is for people which want to use other custom way than ser2net to handle the console.
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ boards:
       interfacenum:	(optional) The interfacenumber of the serial. (Used with two serial in one device)
       use_conmux:	True/False (Use conmux-console instead of ser2net)
       use_ser2net: 	True/False (Deprecated, ser2net is the default uart handler)
-      ser2net_options	(optional) A list of ser2net options to add
+      ser2net_options:	(optional) A list of ser2net options to add
         - option1
         - option2
       use_screen: 	True/False (Use screen via ssh instead of ser2net)


### PR DESCRIPTION
Hi Maintainers,

PR in two commits:
One corrects a minor error in the boards.yaml syntax for ser2net_options. 
The other adds a note about using LOCAL to mitigate telnet disconnects when the board resets serial on power on. For example the R-Car M3 Starter Kit.

I put them together to simplify the PR but can split if you would prefer. I tried to keep the note simple but if you think more explanation is required feel free to let me know or just edit.