### PR TITLE
lava-slave: handle the case where there are no entrypoints to copy

### DIFF
--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -63,7 +63,7 @@ COPY devices/ /root/devices/
 COPY tags/ /root/tags/
 COPY aliases/ /root/aliases/
 COPY deviceinfo/ /root/deviceinfo/
-COPY entrypoint.d/*sh /root/entrypoint.d/
+COPY entrypoint.d/* /root/entrypoint.d/
 RUN chmod +x /root/entrypoint.d/*
 
 RUN if [ -x /usr/local/bin/extra_actions ] ; then /usr/local/bin/extra_actions ; fi


### PR DESCRIPTION
If there are no entrypoint to copy, the COPY docker action will fail.
For fixing this issue, simply copy all files instead of just "*sh".
Since the entrypoint.d directory is not empty (got an .empty file) il
will always works.
The LAVA script run only *sh files so we are still safe.