### PR TITLE
Make docker bind the TFTP server to the correct interface

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -558,7 +558,10 @@ def main():
         if "use_tftp" in worker:
             use_tftp = worker["use_tftp"]
         if use_tftp:
-            dockcomp["services"][name]["ports"].append("69:69/udp")
+            if "dispatcher_ip" in worker:
+                dockcomp["services"][name]["ports"].append(worker["dispatcher_ip"] + ":69:69/udp")
+            else:
+                dockcomp["services"][name]["ports"].append("69:69/udp")
         use_docker = False
         if "use_docker" in worker:
             use_docker = worker["use_docker"]


### PR DESCRIPTION
With UDP, docker sometimes can't route packets to the correct address because the source address gets mangled (see moby/libnetwork#1729).  This happens indeterministically because by default the kernel uses some heuristics to decide which interface to use.  But in some rare circumstances, those can fail and a wrong source address is used.  This can be worked around by explicitly binding to a concrete interface instead of 0.0.0.0.