### PR TITLE
[Fix] Ensure proper filename of public master key

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -501,7 +501,7 @@ def main():
                 if "zmq_auth_key" in worker:
                     shutil.copy(worker["zmq_auth_key"], "%s/zmq_auth/" % workerdir)
                     shutil.copy(worker["zmq_auth_key_secret"], "%s/zmq_auth/" % workerdir)
-                    shutil.copy(worker["zmq_auth_master_key"], "%s/zmq_auth/" % workerdir)
+                    shutil.copy(worker["zmq_auth_master_key"], "%s/zmq_auth/%s.key" % (workerdir,remote_master))
         for fm in masters:
             if fm["name"].lower() == remote_master.lower():
                 slave_master = fm


### PR DESCRIPTION
Currently, the public master key is references as $LAVA_MASTER.key in
e.g. scripts/setup.sh. If the key is named master.key it is copied to
$LAVA_MASTER.key by scripts/setup.sh. However, no nameing convention for the
public master key provided to lavalab-gen.py is documented, so the worker simply
will not start if the key is stored as e.g. master-public.key. Running into such
error scenarios could simply be prevented by copying the public master key to an
appropriatly named file in lavalab-gen.py. This is done here.