### PR TITLE
use_bridge: add option to create virtual bridge inside worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ slaves:
     use_overlay_server:		Does LAVA need an overlay server (default True)
     use_nfs:			Does the LAVA dispatcher will run NFS jobs
     use_tap:			Does TAP netdevices could be used
+    use_bridge:			Does bridge netdevices could be used
     use_docker:			Permit to use docker commands in slave
     arch:			The arch of the worker (if not x86_64), only accept arm64
     host_healthcheck:		If true, enable the optional healthcheck container. See hosting healthchecks below


### PR DESCRIPTION
this option creates a virtual bridge inside a worker that
can be used to create isolated network between two or more
devices(qemu) running inside worker

Signed-off-by: venkata pyla <venkata.pyla@toshiba-tsip.com>