### PR TITLE
Disable IPV6 for tftp

### DIFF
--- a/lava-slave/configs/tftpd-hpa
+++ b/lava-slave/configs/tftpd-hpa
@@ -3,4 +3,4 @@
 TFTP_USERNAME="tftp"
 TFTP_DIRECTORY="/var/lib/lava/dispatcher/tmp/"
 TFTP_ADDRESS="0.0.0.0:69"
-TFTP_OPTIONS="--secure"
+TFTP_OPTIONS="--secure -4"


### PR DESCRIPTION
There is no need to listen on ipv6 inside docker.
Furtheremore, this break lava-docker on non-ipv6 machine.