### PR TITLE
Fix missing healthcheck buildargs

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -543,6 +543,8 @@ def main():
             dockcomp["services"]["healthcheck"]["ports"] = ["8080:8080"]
             dockcomp["services"]["healthcheck"]["build"] = {}
             dockcomp["services"]["healthcheck"]["build"]["context"] = "healthcheck"
+            if "build_args" in master:
+                dockcomp["services"]["healthcheck"]["build"]["args"] = master['build_args']
             shutil.copytree("healthcheck", "output/%s/healthcheck" % host)
         if "extra_actions" in worker:
             fp = open("%s/scripts/extra_actions" % workerdir, "w")


### PR DESCRIPTION
In some cases, buildargs on healthcheck need to be set (like for using proxy during image building). In this case, as healthcheck is a master setting, buildargs are copied from master buildargs settings.
Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>