### PR TITLE
Permit to use bind mount

### DIFF
--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -512,7 +512,8 @@ def main():
                 volume_name = cvolume.split(':')[0]
                 if "volumes" not in dockcomp:
                     dockcomp["volumes"] = {}
-                dockcomp["volumes"][volume_name] = {}
+                if cvolume[0] != '/':
+                    dockcomp["volumes"][volume_name] = {}
         if not "remote_proto" in worker:
             remote_proto = "http"
         else:


### PR DESCRIPTION
The volumes: dict only permit to use volumes, this patch permits to set
also bind mounts.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>