### PR TITLE
Add the ability to configure web interface port

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ You will see it in the "All Jobs" list: http://localhost:10080/scheduler/alljobs
 
 * For more details, see https://validation.linaro.org/static/docs/v2/first-job.html
 
+* Note that the port used above can change depending on the setting of webinterface_port in boards.yaml
+
 ### Adding your first board:
 #### device-type
 To add a board you need to find its device-type, standard naming is to use the same as the official kernel DT name.
@@ -163,7 +165,7 @@ You need to have a PDU for powering your DUT.
 Managing PDUs is done via pdu_generic
 
 ### Network ports
-The following ports are used by lava-docker and are proxyfied on the host:
+By default, the following ports are used by lava-docker and are proxyfied on the host:
 - 69/UDP	proxyfied to the slave for TFTP
 - 80		proxyfied to the slave for TODO (transfer overlay)
 - 5500		proxyfied to the slave for Notification
@@ -217,6 +219,7 @@ masters:
  - name:  lava-master	name of the master
     host: name		name of the host running lava-master (default to "local")
     webadmin_https:	Does the LAVA webadmin is accessed via https
+    webinterface_port: Port number to use for the LAVA web interface (defaut to "10080")
     lava-coordinator:		Does the master should ran a lava-coordinator and export its port
     persistent_db: True/False	(default False) Is the postgres DB is persistent over reboot
     pg_lava_password:		The Postgres lavaserver password to set

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -125,7 +125,7 @@ def main():
             "tokens", "type",
             "users",
             "version",
-            "webadmin_https",
+            "webadmin_https", "webinterface_port",
             ]
         for keyword in master:
             if not keyword in keywords_master:
@@ -139,13 +139,17 @@ def main():
         workerdir = "output/%s/%s" % (host, name)
         os.mkdir("output/%s" % host)
         shutil.copy("deploy.sh", "output/%s/" % host)
+        if not "webinterface_port" in master:
+            webinterface_port = "10080"
+        else:
+            webinterface_port = master["webinterface_port"]
         dockcomp = {}
         dockcomp["version"] = "2.0"
         dockcomp["services"] = {}
         dockcomposeymlpath = "output/%s/docker-compose.yml" % host
         dockcomp["services"][name] = {}
         dockcomp["services"][name]["hostname"] = name
-        dockcomp["services"][name]["ports"] = [ "10080:80", "5555:5555", "5556:5556", "5500:5500" ]
+        dockcomp["services"][name]["ports"] = [ str(webinterface_port) + ":80", "5555:5555", "5556:5556", "5500:5500" ]
         dockcomp["services"][name]["volumes"] = [ "/boot:/boot", "/lib/modules:/lib/modules" ]
         dockcomp["services"][name]["build"] = {}
         dockcomp["services"][name]["build"]["context"] = name


### PR DESCRIPTION
Chomium and other browsers block port 10080 by default with
ERR_UNSAFE_PORT:
https://github.com/chromium/chromium/commit/d6e884b99ffa8ad5f85ae13c5aa78dd297572f19

Add the ability to change the port used for the web interface to avoid
this issue.

Leave 10080 as the default for now to avoid breaking existing setups.

Signed-off-by: Chris Paterson <chris.paterson2@renesas.com>