### PR TITLE
Dockerfile: Static apt-get return code

### DIFF
--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -23,9 +23,9 @@ COPY ser2net.conf /etc
 COPY ser2net.yaml /etc
 
 # PXE stuff
-RUN if [ $(uname -m) != amd64 ]; then dpkg --add-architecture amd64 && apt-get update; fi
-RUN apt-get -y install grub-efi-amd64-bin:amd64
-RUN if [ $(uname -m) != amd64 ]; then dpkg --remove architecture amd64 && apt-get update; fi
+RUN if [ $(uname -m) != amd64 ]; then dpkg --add-architecture amd64 && apt-get update || true; fi
+RUN apt-get -y install grub-efi-amd64-bin:amd64 || true
+RUN if [ $(uname -m) != amd64 ]; then dpkg --remove architecture amd64 && apt-get update || true; fi
 COPY grub.cfg /root/
 
 COPY default/* /etc/default/


### PR DESCRIPTION
Use fixed return code to apt to avoid build failed due to:
```
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
```

as apt-get returns 100 instead success

Signed-off-by: Quirin Gylstorff <quirin.gylstorff@siemens.com>