### PR TITLE
Add healthcheck_repo setting option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ masters:
     pg_lava_password:		The Postgres lavaserver password to set
     http_fqdn:			The FQDN used to access the LAVA web interface. This is necessary if you use https otherwise you will issue CSRF errors.
     healthcheck_url:		Hack healthchecks hosting URL. See hosting healthchecks below
+    healthcheck_repo:		Hack healthchecks git repository URL. See hosting healthchecks below
     build_args:
       - line1			A list of line to set docker build-time variables
       - line2
@@ -513,6 +514,13 @@ Example:
 One master and slave on DC A, and one slave on DC B.
 Both slave need to have healthcheck_host to true and master will have healthcheck_url set to http://healthcheck:8080
 You have to add a DNS server on both slave with an healthcheck entry.
+
+For mirroring the healthcheck repository and keeping it local
+
+- Mirror https://github.com/kernelci/lava-healthchecks-binary to your repository of choice
+- Add your local boards healthchecks binary
+- Set the repository to your new repository using healthcheck_repo on the master
+- Rebuild healthchecks docker container
 
 ## Bugs, Contact
 The prefered way to submit bugs are via the github issue tracker

--- a/healthcheck/Dockerfile
+++ b/healthcheck/Dockerfile
@@ -1,13 +1,10 @@
 FROM bitnami/minideb:stretch
 
 RUN apt-get update && apt-get -y install git
-RUN git clone https://github.com/BayLibre/lava-healthchecks-binary.git
+RUN git clone https://github.com/kernelci/lava-healthchecks-binary.git lava-healthchecks-binary
 
 FROM nginx:mainline-alpine
 
 COPY port.conf /etc/nginx/conf.d/
 
-COPY --from=0 /lava-healthchecks-binary/mainline /usr/share/nginx/html/mainline/
-COPY --from=0 lava-healthchecks-binary/images /usr/share/nginx/html/images/
-COPY --from=0 lava-healthchecks-binary/next /usr/share/nginx/html/next/
-COPY --from=0 lava-healthchecks-binary/stable /usr/share/nginx/html/stable/
+COPY --from=0 /lava-healthchecks-binary/healthchecks /usr/share/nginx/html/healthchecks/

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -119,7 +119,7 @@ def main():
             "allowed_hosts",
             "build_args",
             "groups",
-            "healthcheck_url", "host", "http_fqdn",
+            "healthcheck_url","healthcheck_repo", "host", "http_fqdn",
             "loglevel", "lava-coordinator",
             "name",
             "persistent_db", "pg_lava_password",
@@ -558,6 +558,13 @@ def main():
             if "build_args" in master:
                 dockcomp["services"]["healthcheck"]["build"]["args"] = master['build_args']
             shutil.copytree("healthcheck", "output/%s/healthcheck" % host)
+        if "healthcheck_repo" in master:
+            healthcheckdir = "output/%s/healthcheck" % (host)
+            dockerfile = open("%s/Dockerfile" % healthcheckdir, "r+")
+            dockerfilec = re.sub('(RUN git clone ).*', '\g<1>%s lava-healthchecks-binary' % master["healthcheck_repo"], dockerfile.read())
+            dockerfile.seek(0)
+            dockerfile.write(dockerfilec)
+            dockerfile.close()
         if "extra_actions" in worker:
             fp = open("%s/scripts/extra_actions" % workerdir, "w")
             for eaction in worker["extra_actions"]:


### PR DESCRIPTION
This commit add the setting option `healthcheck_repo` useful for using a personalized healthcheck repository.
example on boards.yaml in the master settings:
`healthcheck_repo: https://github.com/aliceinwire/lava-healthchecks-binary.git`

This will use the https://github.com/aliceinwire/lava-healthchecks-binary.git repository instead of the default https://github.com/baylibre/lava-healthchecks-binary.git