### PR TITLE
Update default LAVA version to 2022.11.1

### DIFF
--- a/lava-master/Dockerfile
+++ b/lava-master/Dockerfile
@@ -1,4 +1,4 @@
-FROM lavasoftware/lava-server:2022.10
+FROM lavasoftware/lava-server:2022.11.1
 
 RUN apt-get update && apt-get -y install sudo git
 

--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM lavasoftware/lava-dispatcher:2022.10
+FROM lavasoftware/lava-dispatcher:2022.11.1
 
 RUN apt-get update
 


### PR DESCRIPTION
Update LAVA version due to 2 new CVE.

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>