### PR TITLE
lava-slave: update ser2net configuration file

### DIFF
--- a/lava-slave/Dockerfile
+++ b/lava-slave/Dockerfile
@@ -19,7 +19,6 @@ COPY conmux/ /etc/conmux/
 RUN find /usr/lib/python3/dist-packages/ -iname constants.py | xargs sed -i 's,XNBD_PORT_RANGE_MIN.*,XNBD_PORT_RANGE_MIN=61950,'
 RUN find /usr/lib/python3/dist-packages/ -iname constants.py | xargs sed -i 's,XNBD_PORT_RANGE_MAX.*,XNBD_PORT_RANGE_MAX=62000,'
 
-COPY ser2net.conf /etc
 COPY ser2net.yaml /etc
 
 # PXE stuff

--- a/lava-slave/scripts/start.sh
+++ b/lava-slave/scripts/start.sh
@@ -10,7 +10,7 @@ fi
 echo "LOGFILE=/var/log/lava-dispatcher/lava-slave.log" >> /etc/lava-dispatcher/lava-slave
 
 service tftpd-hpa start || exit 4
-if [ -s /etc/ser2net.conf ];then
+if [ -s /etc/ser2net.yaml ];then
 	service ser2net start || exit 7
 fi
 

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -731,16 +731,9 @@ def main():
             if use_ser2net:
                 if not worker_name in ser2net_ports:
                     ser2net_ports[worker_name] = ser2net_port_start
-                    fp = open("%s/ser2net.conf" % workerdir, "a")
-                    fp.write("DEFAULT:max-connections:10\n")
-                    fp.close()
                     fp = open("%s/ser2net.yaml" % workerdir, "a")
                     fp.write("%YAML 1.1\n---\n")
                     fp.close()
-                ser2net_line = "%d:telnet:600:/dev/%s:%d 8DATABITS NONE 1STOPBIT" % (ser2net_ports[worker_name], board_name, baud)
-                if "ser2net_options" in uart:
-                    for ser2net_option in uart["ser2net_options"]:
-                        ser2net_line += " %s" % ser2net_option
                 device_line += template_device_ser2net.substitute(port=ser2net_ports[worker_name])
                 # YAML version
                 fp = open("%s/ser2net.yaml" % workerdir, "a")
@@ -748,15 +741,17 @@ def main():
                 fp.write("  accepter: telnet(rfc2217),tcp,%d\n" % ser2net_ports[worker_name])
                 fp.write("  enable: on\n")
                 if set2net_keepopen:
-                    fp.write("  connector: keepopen(retry-time=2000,discard-badwrites),serialdev,/dev/%s,%dn81,local\n" % (board_name, baud))
+                    ser2net_yaml_line= "  connector: keepopen(retry-time=2000,discard-badwrites),serialdev,/dev/%s,%dn81,local" % (board_name, baud)
                 else:
-                    fp.write("  connector: serialdev,/dev/%s,%dn81,local\n" % (board_name, baud))
+                    ser2net_yaml_line = "  connector: serialdev,/dev/%s,%dn81,local" % (board_name, baud)
+                if "ser2net_options" in uart:
+                    for ser2net_yaml_option in uart["ser2net_options"]:
+                        ser2net_yaml_line += ",%s" % ser2net_yaml_option
+                ser2net_yaml_line += "\n"
+                fp.write(ser2net_yaml_line)
                 fp.write("  options:\n")
                 fp.write("    max-connections: 10\n")
-
                 ser2net_ports[worker_name] += 1
-                fp = open("%s/ser2net.conf" % workerdir, "a")
-                fp.write(ser2net_line + " banner\n")
                 fp.close()
         if "connection_command" in board:
             connection_command = board["connection_command"]

--- a/lavalab-gen.py
+++ b/lavalab-gen.py
@@ -710,13 +710,13 @@ def main():
                 dockcomp_add_device(dockcomp, worker_name, "/dev/%s:/dev/%s" % (board_name, board_name))
             use_conmux = False
             use_ser2net = False
-            set2net_keepopen = False
+            ser2net_keepopen = False
             if "use_conmux" in uart:
                 use_conmux = uart["use_conmux"]
             if "use_ser2net" in uart:
                 use_ser2net = uart["use_ser2net"]
-            if "set2net_keepopen" in uart:
-                set2net_keepopen = uart["set2net_keepopen"]
+            if "ser2net_keepopen" in uart:
+                ser2net_keepopen = uart["ser2net_keepopen"]
             if (use_conmux and use_ser2net):
                 print("ERROR: Only one uart handler must be configured")
                 sys.exit(1)
@@ -740,7 +740,7 @@ def main():
                 fp.write("connection: &con%d\n" % ser2net_ports[worker_name])
                 fp.write("  accepter: telnet(rfc2217),tcp,%d\n" % ser2net_ports[worker_name])
                 fp.write("  enable: on\n")
-                if set2net_keepopen:
+                if ser2net_keepopen:
                     ser2net_yaml_line= "  connector: keepopen(retry-time=2000,discard-badwrites),serialdev,/dev/%s,%dn81,local" % (board_name, baud)
                 else:
                     ser2net_yaml_line = "  connector: serialdev,/dev/%s,%dn81,local" % (board_name, baud)


### PR DESCRIPTION
on new versions of ser2net ser2net.conf configuration file as been deprecated and replaced by ser2net.yaml

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>